### PR TITLE
added sort order for payment method

### DIFF
--- a/build/affirm_tar_to_connect_config.php
+++ b/build/affirm_tar_to_connect_config.php
@@ -4,8 +4,8 @@ return array(
 'archive_files'        => 'Affirm_Magento.tar',
 'extension_name'       => 'Affirm_Magento',
 'skip_version_compare' => true,
-'extension_version'    => '2.2.0',
-'archive_connect'      => 'Affirm_Magento-2.2.0.tgz',
+'extension_version'    => '2.2.1',
+'archive_connect'      => 'Affirm_Magento-2.2.1.tgz',
 'path_output'          => realpath('../var/'),
 
 'stability'            => 'stable',

--- a/extension/app/code/community/Affirm/Affirm/etc/config.xml
+++ b/extension/app/code/community/Affirm/Affirm/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Affirm_Affirm>
-            <version>2.2.0</version>
+            <version>2.2.1</version>
         </Affirm_Affirm>
     </modules>
     <global>
@@ -73,6 +73,7 @@
                 <min_order_total>0.01</min_order_total>
                 <max_order_total>100000</max_order_total>
                 <plain_text_title_enabled>0</plain_text_title_enabled>
+                <sort_order>0</sort_order>
             </affirm>
         </payment>
     </default>

--- a/extension/app/code/community/Affirm/Affirm/etc/system.xml
+++ b/extension/app/code/community/Affirm/Affirm/etc/system.xml
@@ -109,6 +109,14 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </detect_xhr_checkout>
+                        <sort_order translate="label">
+                            <label>Sort order</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>230</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </sort_order>
                     </fields>
                 </affirm>
             </groups>

--- a/extension/app/code/community/Affirm/AffirmPromo/etc/config.xml
+++ b/extension/app/code/community/Affirm/AffirmPromo/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Affirm_AffirmPromo>
-            <version>2.2.0</version>
+            <version>2.2.1</version>
         </Affirm_AffirmPromo>
     </modules>
     <global>


### PR DESCRIPTION
Added a sort order setting for the Affirm payment method. Magento core functionality will handle the logic.