### PR TITLE
Fix: Missing Parameters Prevent Checkout with Address that Failed Verification

### DIFF
--- a/extension/skin/frontend/base/default/js/affirm/checkout.js
+++ b/extension/skin/frontend/base/default/js/affirm/checkout.js
@@ -82,13 +82,13 @@ document.observe('dom:loaded', function () {
     if ($('firecheckout-form') || $('onepagecheckout_orderform')) {
         if (typeof checkout.save == 'function') {     // This is for TM Firecheckout
             checkout.save = checkout.save.wrap(
-                function (parentMethod) {
+                function (parentMethod, urlSuffix, forceSave) {
                     if (isAffirmMethod()) {
                         var createAccount = $('billing:register_account');
                         billing.setCreateAccount(createAccount ? createAccount.checked : 1); // create account if checkbox is missing
                         callTMFireCheckoutForAffirm();
                     } else {
-                        return parentMethod();
+                        return parentMethod(urlSuffix, forceSave);
                     }
 
                 }


### PR DESCRIPTION
Fix: The function wrapping for the integration with FireCheckout wasn't passing the required parameters for the `skin/frontend/base/default/tm/firecheckout/js/firecheckout.js::FireCheckout.prototype.save()` function which prevented customers from checking out with an address that didn't passed the verification. To proceed and place an order even when the address isn't validated, a URL parameter is passed as the urlSuffix parameter of the save function.
**Note: The address verification has to be tested with an address located within the United States.**