### PR TITLE
Call to a member function getProductUrl() on null'

### DIFF
--- a/extension/app/code/community/Affirm/Affirm/Model/Payment.php
+++ b/extension/app/code/community/Affirm/Affirm/Model/Payment.php
@@ -550,6 +550,9 @@ class Affirm_Affirm_Model_Payment extends Mage_Payment_Model_Method_Abstract
         $productItems = $products->getItems();
         foreach ($order->getAllVisibleItems() as $orderItem) {
             $product = $productItems[$orderItem->getProductId()];
+            if (!$product instanceof Mage_Sales_Model_Order) {
+                throw new Affirm_Affirm_Exception('Unable to find product entity in order');
+            }
             if (Mage::helper('affirm')->isPreOrder() && $orderItem->getParentItem() &&
                 ($orderItem->getParentItem()->getProductType() == Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE)
             ) {

--- a/extension/app/code/community/Affirm/Affirm/Model/Payment.php
+++ b/extension/app/code/community/Affirm/Affirm/Model/Payment.php
@@ -550,7 +550,7 @@ class Affirm_Affirm_Model_Payment extends Mage_Payment_Model_Method_Abstract
         $productItems = $products->getItems();
         foreach ($order->getAllVisibleItems() as $orderItem) {
             $product = $productItems[$orderItem->getProductId()];
-            if (!$product instanceof Mage_Sales_Model_Order) {
+            if (!$product instanceof Mage_Catalog_Model_Product) {
                 throw new Affirm_Affirm_Exception('Unable to find product entity in order');
             }
             if (Mage::helper('affirm')->isPreOrder() && $orderItem->getParentItem() &&


### PR DESCRIPTION
Resolves an issue where a fatal error is encountered if there is a mismatch between product IDs on an order and the actual products in the database.  This is an issue that happens sporadically in our production environment that can be the result of some data disparity between the order and the catalog.  This PR doesn't resolve the data disparity but it does prevent a fatal error.